### PR TITLE
Fix incorrect URL in refreshToken API request

### DIFF
--- a/client/src/hooks/useSessionManager.ts
+++ b/client/src/hooks/useSessionManager.ts
@@ -14,7 +14,7 @@ export const useSessionManager = () => {
 
   const refreshToken = useCallback(async () => {
     try {
-      const res = await fetch(`${API_BASE}'/auth/refresh-token'`, {
+      const res = await fetch(`${API_BASE}/auth/refresh-token`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
### Description

This pull request fixes an issue with the refreshToken API request where an extra quotation mark caused incorrect URL formatting. This correction ensures the request is sent to the proper endpoint, preventing potential errors in session management.

### Checklist

- [ ] Code builds correctly
- [ ] Tests have been run
- [ ] Documentation has been updated if necessary